### PR TITLE
Bump tomcat-embed-core from 8.5.45 to 8.5.51 in /spring-beans

### DIFF
--- a/spring-beans/pom.xml
+++ b/spring-beans/pom.xml
@@ -47,7 +47,7 @@
         <dependency>
             <groupId>org.apache.tomcat.embed</groupId>
             <artifactId>tomcat-embed-core</artifactId>
-            <version>8.5.45</version>
+            <version>8.5.51</version>
             <scope>test</scope>
         </dependency>
         <!-- junit start -->


### PR DESCRIPTION
Bumps tomcat-embed-core from 8.5.45 to 8.5.51.

Signed-off-by: dependabot[bot] <support@github.com>